### PR TITLE
Add CallingConvention to DllImport

### DIFF
--- a/src/cs/production/C2CS.Feature.BindgenCSharp/Data/CSharpFunctionCallingConvention.cs
+++ b/src/cs/production/C2CS.Feature.BindgenCSharp/Data/CSharpFunctionCallingConvention.cs
@@ -6,5 +6,6 @@ namespace C2CS.Feature.BindgenCSharp.Data;
 public enum CSharpFunctionCallingConvention
 {
     Default = 0,
-    Cdecl
+    Cdecl = 1,
+    StdCall = 2,
 }

--- a/src/cs/production/C2CS.Feature.BindgenCSharp/Logic/CSharpCodeGenerator.cs
+++ b/src/cs/production/C2CS.Feature.BindgenCSharp/Logic/CSharpCodeGenerator.cs
@@ -180,13 +180,21 @@ namespace {namespaceName}
 
     private MethodDeclarationSyntax FunctionExtern(CSharpFunction function)
     {
+        var callingConvention = function.CallingConvention switch
+        {
+            CSharpFunctionCallingConvention.Cdecl => "CallingConvention = CallingConvention.Cdecl",
+            CSharpFunctionCallingConvention.StdCall => "CallingConvention = CallingConvention.StdCall",
+            _ => string.Empty,
+        };
+        var dllImportParameters = string.Join(',', "LibraryName", callingConvention);
+
         var parameterStrings = function.Parameters.Select(
             x => $@"{x.Type.Name} {x.Name}");
         var parameters = string.Join(',', parameterStrings);
 
         var code = $@"
 {function.CodeLocationComment}
-[DllImport(LibraryName)]
+[DllImport({dllImportParameters})]
 public static extern {function.ReturnType.Name} {function.Name}({parameters});
 ";
 

--- a/src/cs/production/C2CS.Feature.BindgenCSharp/Logic/CSharpMapper.cs
+++ b/src/cs/production/C2CS.Feature.BindgenCSharp/Logic/CSharpMapper.cs
@@ -170,7 +170,8 @@ public class CSharpMapper
     {
         var result = cFunctionCallingConvention switch
         {
-            CFunctionCallingConvention.C => Data.CSharpFunctionCallingConvention.Cdecl,
+            CFunctionCallingConvention.Cdecl => Data.CSharpFunctionCallingConvention.Cdecl,
+            CFunctionCallingConvention.StdCall => Data.CSharpFunctionCallingConvention.StdCall,
             _ => throw new ArgumentOutOfRangeException(
                 nameof(cFunctionCallingConvention), cFunctionCallingConvention, null)
         };

--- a/src/cs/production/C2CS.Feature.ExtractAbstractSyntaxTreeC/Data/CFunction.cs
+++ b/src/cs/production/C2CS.Feature.ExtractAbstractSyntaxTreeC/Data/CFunction.cs
@@ -15,7 +15,7 @@ public record CFunction : CNode
     public string Name { get; set; } = string.Empty;
 
     [JsonPropertyName("callingConvention")]
-    public CFunctionCallingConvention CallingConvention { get; set; } = CFunctionCallingConvention.C;
+    public CFunctionCallingConvention CallingConvention { get; set; } = CFunctionCallingConvention.Cdecl;
 
     [JsonPropertyName("returnType")]
     public string ReturnType { get; set; } = null!;

--- a/src/cs/production/C2CS.Feature.ExtractAbstractSyntaxTreeC/Data/CFunctionCallingConvention.cs
+++ b/src/cs/production/C2CS.Feature.ExtractAbstractSyntaxTreeC/Data/CFunctionCallingConvention.cs
@@ -5,6 +5,6 @@ namespace C2CS.Feature.ExtractAbstractSyntaxTreeC.Data;
 
 public enum CFunctionCallingConvention
 {
-    C = 0
-    // TODO: Add more calling conventions
+    Cdecl = 0,
+    StdCall = 1
 }

--- a/src/cs/production/C2CS.Feature.ExtractAbstractSyntaxTreeC/Logic/CTranslationUnitExplorer.cs
+++ b/src/cs/production/C2CS.Feature.ExtractAbstractSyntaxTreeC/Logic/CTranslationUnitExplorer.cs
@@ -874,7 +874,8 @@ public class CTranslationUnitExplorer
         var callingConvention = clang_getFunctionTypeCallingConv(type);
         var result = callingConvention switch
         {
-            CXCallingConv.CXCallingConv_C => CFunctionCallingConvention.C,
+            CXCallingConv.CXCallingConv_C => CFunctionCallingConvention.Cdecl,
+            CXCallingConv.CXCallingConv_X86StdCall => CFunctionCallingConvention.StdCall,
             _ => throw new UseCaseException($"Unknown calling convention '{callingConvention}'.")
         };
 


### PR DESCRIPTION
Some key learnings:
If you want the calling conventions to appear correctly in DllImport, `-m32` needs to be passed to clangArguments in the config. I couldn't find proper documentation, but, all signs point to DllImport ignoring the CallingConvention when the library being loaded is 64-bit.

I considered forcing `-m32` to be passed into clang by default, but wasn't sure what side effects that might have.