### PR TITLE
Use most derived element size for ElementSize

### DIFF
--- a/src/cs/production/C2CS.Feature.ExtractAbstractSyntaxTreeC/Logic/CTranslationUnitExplorer.cs
+++ b/src/cs/production/C2CS.Feature.ExtractAbstractSyntaxTreeC/Logic/CTranslationUnitExplorer.cs
@@ -1261,10 +1261,24 @@ public class CTranslationUnitExplorer
         var isSystemType = type.IsSystem();
 
         int? elementSize = null;
-        if (type.kind == CXTypeKind.CXType_ConstantArray)
+        var elementType = type;
+
+        while (true)
         {
-            var elementType = clang_getElementType(type);
-            elementSize = (int)clang_Type_getSizeOf(elementType);
+            if (elementType.kind == CXTypeKind.CXType_ConstantArray)
+            {
+                elementType = clang_getElementType(elementType);
+                elementSize = (int)clang_Type_getSizeOf(elementType);
+            }
+            else if (elementType.kind == CXTypeKind.CXType_Pointer)
+            {
+                elementType = clang_getPointeeType(elementType);
+                elementSize = (int)clang_Type_getSizeOf(elementType);
+            }
+            else
+            {
+                break;
+            }
         }
 
         ClangLocation? location = null;


### PR DESCRIPTION
I've made it so that the element type is based on the most derived element type. I've also added support for pointers.

Originally when `machineBitWidth` was set to 64, int* would translate to long* in C# because it would default to the pointer's size since no ElementSize was specified before.

Without the loop, this would continue to happen with int** translating to long**.