### PR TITLE
Fix function pointer C location + C# type equality

### DIFF
--- a/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/Explore/ExploreContext.cs
+++ b/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/Explore/ExploreContext.cs
@@ -486,6 +486,11 @@ enum {
         int? fieldIndex = null)
     {
         var location = Location(cursor, type);
+        if (location.IsNull && parentInfo?.Kind == CKind.TypeAlias)
+        {
+            location = parentInfo.Location;
+        }
+
         var typeNameActual = TypeName(kind, type, parentInfo?.Name, fieldIndex);
         var nameActual = !string.IsNullOrEmpty(name) ? name : typeNameActual;
         var sizeOf = SizeOf(kind, type);

--- a/src/cs/production/contexts/C2CS.Contexts.WriteCodeCSharp/Data/Model/CSharpType.cs
+++ b/src/cs/production/contexts/C2CS.Contexts.WriteCodeCSharp/Data/Model/CSharpType.cs
@@ -3,7 +3,7 @@
 
 namespace C2CS.Contexts.WriteCodeCSharp.Data.Model;
 
-public sealed record CSharpType
+public sealed record CSharpType : IEquatable<CSharpType>
 {
     public string Name { get; init; } = string.Empty;
 
@@ -20,5 +20,29 @@ public sealed record CSharpType
     public override string ToString()
     {
         return string.IsNullOrEmpty(Name) ? string.Empty : Name;
+    }
+
+    public bool Equals(CSharpType? other)
+    {
+        if (ReferenceEquals(null, other))
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        var isEqual = Name == other.Name &&
+                      SizeOf == other.SizeOf &&
+                      AlignOf == other.AlignOf &&
+                      ArraySizeOf == other.ArraySizeOf;
+        return isEqual;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Name, SizeOf, AlignOf, ArraySizeOf);
     }
 }


### PR DESCRIPTION
Fixes:
- Null location for typedef function pointers; when function pointer is from typedef, the location should be from the typedef.
- Splitting behaviour of C# generated code into different platforms via C# type equality; only use the C# mapped name for equality and ignore the C name.