### PR TITLE
Block specific functions

### DIFF
--- a/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Data/ReadCodeCConfiguration.cs
+++ b/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Data/ReadCodeCConfiguration.cs
@@ -34,15 +34,19 @@ public sealed class ReadCodeCConfiguration : UseCaseConfiguration
     [Json.Schema.Generation.Description("Determines whether to include or exclude functions. Use `true` or to include functions. Use `false` to exclude functions. Default is `true`. See the `functions` property to control which ones are explicitly allowed.")]
     public bool? IsEnabledFunctions { get; set; }
 
-    [JsonPropertyName("functions")]
+    [JsonPropertyName("functions_allowed")]
     [Json.Schema.Generation.Description("The function names to explicitly include. Default is `null`. If `null`, all functions found may be included only if `is_enabled_functions` is `true`. Note that function which are excluded may also exclude any transitive types.")]
     public ImmutableArray<string?>? FunctionNamesAllowed { get; set; }
+
+    [JsonPropertyName("functions_blocked")]
+    [Json.Schema.Generation.Description("The function names to explicitly exclude. Default is `null`. Note that function which are excluded may also exclude any transitive types.")]
+    public ImmutableArray<string?>? FunctionNamesBlocked { get; set; }
 
     [JsonPropertyName("is_enabled_variables")]
     [Json.Schema.Generation.Description("Determines whether to include or exclude variables. Use `true` to include variables. Use `false` to exclude variables. Default is `true`. See the `variables` property to control which ones are explicitly allowed.")]
     public bool? IsEnabledVariables { get; set; }
 
-    [JsonPropertyName("variables")]
+    [JsonPropertyName("variables_allowed")]
     [Json.Schema.Generation.Description("The variable names to explicitly include. Default is `null`. If `null`, all variables found may be included only if `is_enabled_variables` is `true`. Note that variables which are excluded may also exclude any transitive types.")]
     public ImmutableArray<string?>? VariableNamesAllowed { get; set; }
 
@@ -50,7 +54,7 @@ public sealed class ReadCodeCConfiguration : UseCaseConfiguration
     [Json.Schema.Generation.Description("Determines whether to include or exclude macro objects. Use `true` to include macro objects. Use `false` to exclude all macro objects. Default is `true`. See the `macro_objects` property to control which ones are explicitly allowed.")]
     public bool? IsEnabledMacroObjects { get; set; }
 
-    [JsonPropertyName("macro_objects")]
+    [JsonPropertyName("macro_objects_allowed")]
     [Json.Schema.Generation.Description("The macro object names to explicitly include. Default is `null`. If `null`, all macro objects found may be included only if `is_enabled_macro_objects` is `true`. Note that macro objects which are excluded may also exclude any transitive types.")]
     public ImmutableArray<string?>? MacroObjectNamesAllowed { get; set; }
 
@@ -58,7 +62,7 @@ public sealed class ReadCodeCConfiguration : UseCaseConfiguration
     [Json.Schema.Generation.Description("Determines whether to include or exclude enum constants. Use `true` to include enum constants. Use `false` to exclude all enum constants. Default is `false`. See the `enum_constants` property to control which ones are explicitly allowed.")]
     public bool? IsEnabledEnumConstants { get; set; }
 
-    [JsonPropertyName("enum_constants")]
+    [JsonPropertyName("enum_constants_allowed")]
     [Json.Schema.Generation.Description("The enum constant names to explicitly include. Default is `null`. If `null`, all enum constants found may be included only if `is_enabled_enum_constants` is `true`.")]
     public ImmutableArray<string?>? EnumConstantNamesAllowed { get; set; }
 
@@ -66,9 +70,9 @@ public sealed class ReadCodeCConfiguration : UseCaseConfiguration
     [Json.Schema.Generation.Description("Determines whether to include or exclude enums that are independent to a root node such as a function or variable. Use `true` to include dangling enums. Use `false` to exclude all dangling enums. Default is `false`. See the `dangling_enums` property to control which ones are explicitly allowed.")]
     public bool? IsEnabledEnumsDangling { get; set; }
 
-    [JsonPropertyName("dangling_enums")]
+    [JsonPropertyName("dangling_enums_allowed")]
     [Json.Schema.Generation.Description("The dangling enum names to explicitly include. Default is `null`. If `null`, all dangling enums found may be included only if `is_enabled_dangling_enums` is `true`.")]
-    public ImmutableArray<string?>? DanglingEnumNames { get; set; }
+    public ImmutableArray<string?>? DanglingEnumNamesAllowed { get; set; }
 
     [JsonPropertyName("opaque_types")]
     [Json.Schema.Generation.Description("Type names that may be found when parsing C code that will be re-interpreted as opaque types. Opaque types are often used with a pointer to hide the information about the bit layout behind the pointer.")]

--- a/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/Explore/ExploreContext.cs
+++ b/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/Explore/ExploreContext.cs
@@ -516,7 +516,7 @@ enum {
         var userIncludeDirectories = ExploreOptions.IsEnabledLocationFullPaths
             ? ImmutableArray<string>.Empty
             : ParseOptions.UserIncludeDirectories;
-        return cursor.Location(type, _linkedPaths, userIncludeDirectories);
+        return cursor.GetLocation(type, _linkedPaths, userIncludeDirectories);
     }
 
     private int SizeOf(CKind kind, CXType type)

--- a/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/Explore/ExploreOptions.cs
+++ b/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/Explore/ExploreOptions.cs
@@ -9,11 +9,13 @@ public class ExploreOptions
 {
     public ImmutableHashSet<string> HeaderFilesBlocked { get; init; } = ImmutableHashSet<string>.Empty;
 
-    public ImmutableArray<string> OpaqueTypesNames { get; init; } = ImmutableArray<string>.Empty;
+    public ImmutableHashSet<string> OpaqueTypesNames { get; init; } = ImmutableHashSet<string>.Empty;
 
-    public ImmutableArray<string> FunctionNamesAllowed { get; init; } = ImmutableArray<string>.Empty;
+    public ImmutableHashSet<string> FunctionNamesAllowed { get; init; } = ImmutableHashSet<string>.Empty;
 
-    public ImmutableArray<string> EnumConstantNamesAllowed { get; init; } = ImmutableArray<string>.Empty;
+    public ImmutableHashSet<string> FunctionNamesBlocked { get; init; } = ImmutableHashSet<string>.Empty;
+
+    public ImmutableHashSet<string> EnumConstantNamesAllowed { get; init; } = ImmutableHashSet<string>.Empty;
 
     public bool IsEnabledLocationFullPaths { get; init; }
 

--- a/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/Explore/Handlers/EnumConstantExplorer.cs
+++ b/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/Explore/Handlers/EnumConstantExplorer.cs
@@ -29,8 +29,19 @@ public class EnumConstantExplorer : ExploreHandler<CEnumConstant>
             return false;
         }
 
-        var namedAllowed = context.ExploreOptions.EnumConstantNamesAllowed;
-        return namedAllowed.IsDefaultOrEmpty || namedAllowed.Contains(name);
+        var options = context.ExploreOptions;
+
+        if (options.EnumConstantNamesAllowed.Contains(name))
+        {
+            return true;
+        }
+
+        if (!options.EnumConstantNamesAllowed.IsEmpty)
+        {
+            return false;
+        }
+
+        return true;
     }
 
     public override CEnumConstant Explore(ExploreContext context, ExploreInfoNode info)

--- a/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/Explore/Handlers/FunctionExplorer.cs
+++ b/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/Explore/Handlers/FunctionExplorer.cs
@@ -34,8 +34,24 @@ public sealed class FunctionExplorer : ExploreHandler<CFunction>
             return false;
         }
 
-        var namesAllowed = context.ExploreOptions.FunctionNamesAllowed;
-        return namesAllowed.IsDefaultOrEmpty || namesAllowed.Contains(name);
+        var options = context.ExploreOptions;
+
+        if (options.FunctionNamesAllowed.Contains(name))
+        {
+            return true;
+        }
+
+        if (!options.FunctionNamesAllowed.IsEmpty)
+        {
+            return false;
+        }
+
+        if (options.FunctionNamesBlocked.Contains(name))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     public override CFunction Explore(ExploreContext context, ExploreInfoNode info)

--- a/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/Parse/ParseOptions.cs
+++ b/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/Parse/ParseOptions.cs
@@ -15,7 +15,7 @@ public class ParseOptions
 
     public ImmutableArray<string> AdditionalArguments { get; init; } = ImmutableArray<string>.Empty;
 
-    public ImmutableArray<string> MacroObjectNamesAllowed { get; init; } = ImmutableArray<string>.Empty;
+    public ImmutableHashSet<string> MacroObjectNamesAllowed { get; init; } = ImmutableHashSet<string>.Empty;
 
     public bool IsEnabledFindSystemHeaders { get; init; }
 

--- a/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/Parse/Parser.cs
+++ b/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/Parse/Parser.cs
@@ -295,7 +295,7 @@ public sealed partial class Parser
 
     private static CLocation MacroLocation(CXCursor cursor, StreamReader reader, ref int readerLineNumber)
     {
-        var location = cursor.Location(null, null, null);
+        var location = cursor.GetLocation(null, null, null);
         var locationCommentLineNumber = location.LineNumber - 1;
 
         if (readerLineNumber > locationCommentLineNumber)
@@ -496,19 +496,19 @@ int main(void)
 
     private static MacroObjectCandidate? MacroObjectCandidate(
         CXCursor cursor,
-        ImmutableArray<string> macroObjectNamesAllowed,
+        ImmutableHashSet<string> macroObjectNamesAllowed,
         ImmutableDictionary<string, string> linkedPaths,
         ImmutableArray<string>? userIncludeDirectories)
     {
         var name = cursor.Name();
 
-        var isAllowed = macroObjectNamesAllowed.IsDefaultOrEmpty || macroObjectNamesAllowed.Contains(name);
+        var isAllowed = macroObjectNamesAllowed.Contains(name) || macroObjectNamesAllowed.IsEmpty;
         if (!isAllowed)
         {
             return null;
         }
 
-        var location = cursor.Location(null, linkedPaths, userIncludeDirectories);
+        var location = cursor.GetLocation(null, linkedPaths, userIncludeDirectories);
 
         // clang doesn't have a thing where we can easily get a value of a macro
         // we need to:

--- a/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/ReadCodeCValidator.cs
+++ b/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/ReadCodeCValidator.cs
@@ -75,10 +75,11 @@ public sealed class ReadCodeCValidator : UseCaseValidator<ReadCodeCConfiguration
         var outputFilePath = VerifyOutputFilePath(configuration.OutputFileDirectory, targetPlatform);
 
         var excludedHeaderFiles = VerifyImmutableArray(configurationPlatform?.HeaderFilesBlocked).ToImmutableHashSet();
-        var opaqueTypeNames = VerifyImmutableArray(configuration.OpaqueTypeNames);
-        var functionNamesAllowed = VerifyImmutableArray(configuration.FunctionNamesAllowed);
-        var macroObjectNamesAllowed = VerifyImmutableArray(configuration.MacroObjectNamesAllowed);
-        var enumConstantNamesAllowed = VerifyImmutableArray(configuration.EnumConstantNamesAllowed);
+        var opaqueTypeNames = VerifyImmutableArray(configuration.OpaqueTypeNames).ToImmutableHashSet();
+        var functionNamesAllowed = VerifyImmutableArray(configuration.FunctionNamesAllowed).ToImmutableHashSet();
+        var functionNamesBlocked = VerifyImmutableArray(configuration.FunctionNamesBlocked).ToImmutableHashSet();
+        var macroObjectNamesAllowed = VerifyImmutableArray(configuration.MacroObjectNamesAllowed).ToImmutableHashSet();
+        var enumConstantNamesAllowed = VerifyImmutableArray(configuration.EnumConstantNamesAllowed).ToImmutableHashSet();
         var clangDefines = VerifyImmutableArray(configurationPlatform?.Defines);
         var clangArguments = VerifyImmutableArray(configurationPlatform?.ClangArguments);
 
@@ -93,6 +94,7 @@ public sealed class ReadCodeCValidator : UseCaseValidator<ReadCodeCConfiguration
                 HeaderFilesBlocked = excludedHeaderFiles,
                 OpaqueTypesNames = opaqueTypeNames,
                 FunctionNamesAllowed = functionNamesAllowed,
+                FunctionNamesBlocked = functionNamesBlocked,
                 EnumConstantNamesAllowed = enumConstantNamesAllowed,
                 IsEnabledLocationFullPaths = configuration.IsEnabledLocationFullPaths ?? false,
                 IsEnabledFunctions = configuration.IsEnabledFunctions ?? true,


### PR DESCRIPTION
Not really a fix for #97, but the solution is allow blocking of functions by name. For some reason parsing the header with Clang on Windows with MSCV defines is making the function be seen for DLL export when it is not.