### PR TITLE
Add /usr/lib/libclang.so to search file paths

### DIFF
--- a/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/Parse/ClangInstaller.cs
+++ b/src/cs/production/contexts/C2CS.Contexts.ReadCodeC/Domain/Parse/ClangInstaller.cs
@@ -91,6 +91,7 @@ public sealed partial class ClangInstaller
         {
             // ReSharper disable StringLiteralTypo
             Path.Combine(AppContext.BaseDirectory, "libclang.so"),
+            "/usr/lib/libclang.so",
             "/usr/lib/llvm-10/lib/libclang.so.1" // apt-get install clang
             // ReSharper restore StringLiteralTypo
         };


### PR DESCRIPTION
some linux distribution put such as archlinux put libclang.so in /usr/lib/libclang.so https://archlinux.org/packages/extra/x86_64/clang/files/