### PR TITLE
Fix type alias function pointers for abstract syntax tree

### DIFF
--- a/src/cs/production/executables/C2CS.Tool/ReadCodeC/Domain/Explore/ExploreContext.cs
+++ b/src/cs/production/executables/C2CS.Tool/ReadCodeC/Domain/Explore/ExploreContext.cs
@@ -74,15 +74,16 @@ public sealed class ExploreContext
             kind = kindHint.Value;
         }
 
-        while (rootInfo != null && rootInfo.Location == CLocation.NoLocation)
-        {
-            rootInfo = rootInfo.Parent;
-        }
-
         var cursor = clang_getTypeDeclaration(type);
         var typeName = TypeName(kind, type, rootInfo?.Name, rootInfo?.Kind, fieldIndex);
 
-        var typeInfo = VisitTypeInternal(kind, typeName, type, typeCandidate, cursor, rootInfo, null);
+        var rootInfoWithLocation = rootInfo;
+        while (rootInfoWithLocation != null && rootInfoWithLocation.Location == CLocation.NoLocation)
+        {
+            rootInfoWithLocation = rootInfoWithLocation.Parent;
+        }
+
+        var typeInfo = VisitTypeInternal(kind, typeName, type, typeCandidate, cursor, rootInfoWithLocation, null);
 
         return typeInfo;
     }

--- a/src/cs/production/executables/C2CS.Tool/ReadCodeC/Domain/Explore/Handlers/TypeAliasExplorer.cs
+++ b/src/cs/production/executables/C2CS.Tool/ReadCodeC/Domain/Explore/Handlers/TypeAliasExplorer.cs
@@ -21,16 +21,21 @@ public class TypeAliasExplorer : ExploreNodeHandler<CTypeAlias>
 
     protected override ExploreKindTypes ExpectedTypes { get; } = ExploreKindTypes.Is(CXTypeKind.CXType_Typedef);
 
-    protected override CTypeAlias Explore(ExploreContext context, ExploreInfoNode info)
+    protected override CTypeAlias? Explore(ExploreContext context, ExploreInfoNode info)
     {
         var typeAlias = TypeAlias(context, info);
         return typeAlias;
     }
 
-    private static CTypeAlias TypeAlias(ExploreContext context, ExploreInfoNode info)
+    private static CTypeAlias? TypeAlias(ExploreContext context, ExploreInfoNode info)
     {
         var aliasType = clang_getTypedefDeclUnderlyingType(info.Cursor);
         var aliasTypeInfo = context.VisitType(aliasType, info)!;
+
+        if (aliasTypeInfo.Name == info.Name && aliasTypeInfo.Kind == CKind.FunctionPointer)
+        {
+            return null;
+        }
 
         var typedef = new CTypeAlias
         {


### PR DESCRIPTION
Found when generating bindings for Windows for SDL3, the following function pointer was not handled correctly when reading the abstract syntax tree:

```c
typedef uintptr_t (__cdecl * pfnSDL_CurrentBeginThread)
                   (void *, unsigned, unsigned (__stdcall *func)(void *),
                    void * /*arg*/, unsigned, unsigned * /* threadID */);
```