### PR TITLE
Fix startup time on linux

### DIFF
--- a/src/cs/production/c2cs.Tool/Startup.cs
+++ b/src/cs/production/c2cs.Tool/Startup.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -54,6 +55,12 @@ public static class Startup
 
         foreach (var originalSource in sources)
         {
+            // Skip automatically added JSON sources to avoid https://github.com/dotnet/runtime/issues/53715
+            if (originalSource is JsonConfigurationSource)
+            {
+                continue;
+            }
+
             _ = builder.Add(originalSource);
         }
     }


### PR DESCRIPTION
## Motivation

Fixes: https://github.com/bottlenoselabs/c2cs/issues/184

## Explanation

- The `HostBuilder` is responsible for configuring JsonConfigurationSources automatically for `appsettings`
- Those sources have reloadOnChange enabled
- On Linux, this leads to an enumeration of the complete folder including subdirectories: https://github.com/dotnet/runtime/issues/53715

## Changes

Do not add back automatically added JsonConfigurationSources. As far as I understand, they are not used anyway.

## Other solutions considered

- Setting `DOTNET_USE_POLLING_FILE_WATCHER=1` (see linked issue) fixes startup times, but is not really feasible